### PR TITLE
Generate 400MHz RD_EN pulse and phase-shifted VSAEN

### DIFF
--- a/DRAM_Write_read_16core_v5_200MHz.v
+++ b/DRAM_Write_read_16core_v5_200MHz.v
@@ -2562,7 +2562,8 @@ module DRAM_write_read_16core(
     reg RD_EN_pre_r;
     reg RD_EN_r1;
     reg RD_EN_r2;
-    reg RD_EN_r3; // 在400MHz域打一拍后的读使能
+    reg RD_EN_r3; // 在400MHz域生成的单周期读使能
+    reg RD_EN_r4; // 在VSAEN生成后再打一拍的读使能
     // 在200MHz域寄存RD_EN_pre并屏蔽写操作
     always @(posedge clk_200m or negedge rst_n) begin
         if(!rst_n) begin
@@ -2578,14 +2579,16 @@ module DRAM_write_read_16core(
             RD_EN_r1 <= 1'b0;
             RD_EN_r2 <= 1'b0;
             RD_EN_r3 <= 1'b0;
+            RD_EN_r4 <= 1'b0;
         end
         else begin
             RD_EN_r1 <= RD_EN_pre_r;
             RD_EN_r2 <= RD_EN_r1;
-            RD_EN_r3 <= RD_EN_r1 & (~RD_EN_r2); // 400MHz域打一拍
+            RD_EN_r3 <= RD_EN_r1 & (~RD_EN_r2); // 400MHz域的单周期脉冲
+            RD_EN_r4 <= RD_EN_r3; // RD_EN在给VSAEN赋值后再打一拍
         end
     end
-    assign RD_EN = RD_EN_r3;
+    assign RD_EN = RD_EN_r4;
     reg VSAEN_r;
     reg VSAEN_nr1;
     always @(posedge clk_vsa or negedge rst_n) begin
@@ -2594,7 +2597,7 @@ module DRAM_write_read_16core(
             VSAEN_nr1 <= 1'b0;
         end
         else begin
-            VSAEN_nr1 <= RD_EN_r3;
+            VSAEN_nr1 <= RD_EN_r3; // VSAEN由RD_EN_r3相移获得
             VSAEN_r <= VSAEN_nr1;
         end
     end

--- a/DRAM_Write_read_16core_v5_200MHz.v
+++ b/DRAM_Write_read_16core_v5_200MHz.v
@@ -23,6 +23,7 @@
 module DRAM_write_read_16core(
     input wire clk_100m,
     input wire clk_200m,
+    input wire clk_400m,
     input wire clk_vsa,
     input wire rst_n,
     // 使能读写
@@ -2557,17 +2558,34 @@ module DRAM_write_read_16core(
     
     assign LIM_IN=DATA_IN_r;     // LIM_IN, LIM输入 16块芯片的算输入数据
     assign LIM_SEL=CIM_model_r;  // 存算模式选择
-    // 插入逻辑门延时  具体延时多少是试出来的
-    reg RD_EN_r;
+    // 在400MHz时钟域产生单周期的RD_EN脉冲
+    reg RD_EN_pre_r;
+    reg RD_EN_r1;
+    reg RD_EN_r2;
+    reg RD_EN_r3; // 在400MHz域打一拍后的读使能
+    // 在200MHz域寄存RD_EN_pre并屏蔽写操作
     always @(posedge clk_200m or negedge rst_n) begin
         if(!rst_n) begin
-            RD_EN_r <= 1'b0;
+            RD_EN_pre_r <= 1'b0;
         end
         else begin
-            RD_EN_r <= RD_EN_pre & (~WR_flag);
+            RD_EN_pre_r <= RD_EN_pre & (~WR_flag);
         end
     end
-    assign RD_EN = RD_EN_r;
+    // 跨到400MHz域并生成一个400MHz时钟周期的脉冲
+    always @(posedge clk_400m or negedge rst_n) begin
+        if(!rst_n) begin
+            RD_EN_r1 <= 1'b0;
+            RD_EN_r2 <= 1'b0;
+            RD_EN_r3 <= 1'b0;
+        end
+        else begin
+            RD_EN_r1 <= RD_EN_pre_r;
+            RD_EN_r2 <= RD_EN_r1;
+            RD_EN_r3 <= RD_EN_r1 & (~RD_EN_r2); // 400MHz域打一拍
+        end
+    end
+    assign RD_EN = RD_EN_r3;
     reg VSAEN_r;
     reg VSAEN_nr1;
     always @(posedge clk_vsa or negedge rst_n) begin
@@ -2576,7 +2594,7 @@ module DRAM_write_read_16core(
             VSAEN_nr1 <= 1'b0;
         end
         else begin
-            VSAEN_nr1 <= RD_EN;
+            VSAEN_nr1 <= RD_EN_r3;
             VSAEN_r <= VSAEN_nr1;
         end
     end


### PR DESCRIPTION
## Summary
- add clk_400m input to support RD_EN pulse generation at 400 MHz
- synchronize RD_EN_pre into 400 MHz domain to create single-cycle pulse
- derive VSAEN from phase-shifted clock based on new RD_EN
- delay RD_EN by one 400 MHz cycle to align with VSAEN generation

## Testing
- ❌ `verilator --lint-only DRAM_Write_read_16core_v5_200MHz.v` (command not found)
- ⚠️ `apt-get update` (403  Forbidden [IP: 172.30.0.179 8080])
- ❌ `iverilog -g2012 -tnull DRAM_Write_read_16core_v5_200MHz.v` (command not found)


------
https://chatgpt.com/codex/tasks/task_e_68b532321e6083268e95db43828df88a